### PR TITLE
Fix sleep mode

### DIFF
--- a/open_myo.py
+++ b/open_myo.py
@@ -31,7 +31,7 @@ class Services(btle.Peripheral):
             self.writeCharacteristic(WriteHandle.COMMAND, struct.pack('<3B', 3, 1, length))
 
     def sleep_mode(self, mode):
-        self.writeCharacteristic(WriteHandle.COMMAND, struct.pack('<3B', 9, 1, mode))
+        self.writeCharacteristic(WriteHandle.COMMAND, struct.pack('<3B', 9, 1, mode), True)
 
     def power_off(self):
         self.writeCharacteristic(WriteHandle.COMMAND, b'\x04\x00')


### PR DESCRIPTION
Fix issue #3. Set the withResponse parameter to True in order to await the confirmation when setting the sleep mode to make it work.

I've set withResponse=True in all cases except for powering the device off in my implementation (https://github.com/qtux/myo-raw). Maybe you want to consider it as well, it could be more reliable that way.